### PR TITLE
[SDK-#] Update SDK version to 12.4.0 and some app improvements

### DIFF
--- a/app.xcodeproj/project.pbxproj
+++ b/app.xcodeproj/project.pbxproj
@@ -1382,7 +1382,7 @@
 			repositoryURL = "https://github.com/2gis/mobile-sdk-full-swift-package.git";
 			requirement = {
 				kind = exactVersion;
-				version = 12.3.0;
+				version = 12.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/2gis/mobile-sdk-full-swift-package.git",
       "state" : {
-        "revision" : "7cdaa6f2c6d80c01a37abec8dee1bafe83fe5db8",
-        "version" : "12.3.0"
+        "revision" : "88627cc7fd2c9c10e9cd24386cb67c0bf7659b1e",
+        "version" : "12.4.0"
       }
     }
   ],

--- a/app/Info.plist
+++ b/app/Info.plist
@@ -56,6 +56,8 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>UTImportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/app/Views/DemoPages/RouteSearch/RouteView/RouteView.swift
+++ b/app/Views/DemoPages/RouteSearch/RouteView/RouteView.swift
@@ -61,10 +61,10 @@ struct RouteView: View {
 				Spacer()
 			}
 		}
-		.contentShape(Rectangle())
-		.longPressAndDragRecognizer { state in
-			self.viewModel.handleDragGesture(state)
-		}
+//		.contentShape(Rectangle())
+//		.longPressAndDragRecognizer { state in
+//			self.viewModel.handleDragGesture(state)
+//		}
 	}
 
 	@ViewBuilder

--- a/app/Views/Root/RootViewFactory.swift
+++ b/app/Views/Root/RootViewFactory.swift
@@ -257,6 +257,7 @@ final class RootViewFactory: ObservableObject {
 
 	private func makeMapOptions() -> MapOptions {
 		var options = MapOptions.default
+		options.maxFps = UIScreen.main.maximumFramesPerSecond
 		options.graphicsPreset = self.settingsService.graphicsOption.preset
 		if let styleUrl = self.settingsService.customStyleUrl {
 			options.styleFuture = self.styleFactory.loadFile(url: styleUrl)


### PR DESCRIPTION
• Update the SDK version to 12.4.0
• Disable the FPS cap on displays with refresh rates higher than 60Hz.
• Disable the custom gesture recognizer as it interferes with map gestures on iOS 17 and later.